### PR TITLE
allow PUT as api option

### DIFF
--- a/lib/framework/fantasyRequest.js
+++ b/lib/framework/fantasyRequest.js
@@ -40,7 +40,8 @@ FantasyRequest.prototype._request = function(deferred, url, type, data) {
     
     switch (type) {
         case "POST":
-            oauth.post(url,
+        case "PUT":
+            oauth[type.toLowerCase()](url,
                 this.req.session.oauthAccessToken,
                 this.req.session.oauthAccessTokenSecret,
                 data,

--- a/test/fantasySports.spec.js
+++ b/test/fantasySports.spec.js
@@ -220,5 +220,47 @@ describe("FantasySports", function() {
 
             FantasySports.auth.getOAuth.restore();
         });
+
+        it("should accept puts", function () {
+            var request = {
+                    session: { 
+                        oauthAccessToken: "abc123"
+                    }
+                },
+                response = {};
+
+            sinon.stub(FantasySports.auth, "getOAuth")
+                .returns({
+                    put: function(url, accessToken, accessTokenSecret, data, dataType, callback) {
+                        callback(null, {
+                            success: true
+                        });
+                    }
+                });
+
+            FantasySports
+                .request(request, response)
+                .api("users;use_login=1/games;game_keys=nfl/leagues?format=json", "PUT", {
+                    fantasy_content: {
+                    roster: {
+                        coverage_type: "week",
+                        week: "1",
+                        players: [
+                            {
+                                player: {
+                                    player_key: "123",
+                                    position: "BN"
+                                }
+                            }
+                        ]
+                    }
+                }
+                })
+                .done(function(data) {  
+                    expect(data.success).to.be.ok();
+                });
+
+            FantasySports.auth.getOAuth.restore();
+        });
     });
 });


### PR DESCRIPTION
some yahoo api options only allow put and not post (Roster resource)

On a side note, have you successfully done a post or put to the yahoo api using JSON? I added a test like the one you did for post using JSON. However, I can only get yahoo to accept XML in a post or put.
